### PR TITLE
Add tests for navigating the dropdown menu, changing check-in date/time, and submitting without a barcode

### DIFF
--- a/CheckIn.js
+++ b/CheckIn.js
@@ -33,7 +33,9 @@ class CheckIn extends React.Component {
   }
 
   focusInput() {
-    this.barcodeEl.current.getRenderedComponent().focusInput();
+    if (this.barcodeEl.current) {
+      this.barcodeEl.current.getRenderedComponent().focusInput();
+    }
   }
 
   render() {
@@ -127,22 +129,26 @@ class CheckIn extends React.Component {
                     </Layout>
                   </Col>
                   <Col xs={12} smOffset={2} sm={2}>
-                    <Field
-                      name="item.checkinDate"
-                      aria-label={checkinDateLabel}
-                      label={processLabel}
-                      component={Datepicker}
-                      passThroughValue="today"
-                    />
+                    <div data-test-process-date>
+                      <Field
+                        name="item.checkinDate"
+                        aria-label={checkinDateLabel}
+                        label={processLabel}
+                        component={Datepicker}
+                        passThroughValue="today"
+                      />
+                    </div>
                   </Col>
                   <Col xs={12} sm={2}>
-                    <Field
-                      name="item.checkinTime"
-                      aria-label={checkinTimeLabel}
-                      label={timeReturnedLabel}
-                      component={Timepicker}
-                      passThroughValue="now"
-                    />
+                    <div data-test-process-time>
+                      <Field
+                        name="item.checkinTime"
+                        aria-label={checkinTimeLabel}
+                        label={timeReturnedLabel}
+                        component={Timepicker}
+                        passThroughValue="now"
+                      />
+                    </div>
                   </Col>
                   <Col xs={12} sm={1}>
                     <Layout className="marginTopLabelSpacer">

--- a/Scan.js
+++ b/Scan.js
@@ -121,22 +121,19 @@ class Scan extends React.Component {
     }
   }
 
-  showLoanDetails(loan, e) {
-    if (e) e.preventDefault();
+  showLoanDetails(loan) {
     this.props.mutator.query.update({
       _path: `/users/view/${loan.userId}?layer=loan&loan=${loan.id}`,
     });
   }
 
-  showPatronDetails(loan, e) {
-    if (e) e.preventDefault();
+  showPatronDetails(loan) {
     this.props.mutator.query.update({
       _path: `/users/view/${_.get(loan, ['patron', 'id'])}`,
     });
   }
 
-  showItemDetails(loan, e) {
-    if (e) e.preventDefault();
+  showItemDetails(loan) {
     this.props.mutator.query.update({
       _path: `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`,
     });
@@ -163,9 +160,11 @@ class Scan extends React.Component {
               </div>
             </MenuItem>
             <MenuItem itemMeta={{ loan, action: 'showItemDetails' }}>
-              <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`}>
-                <FormattedMessage id="ui-checkin.itemDetails" />
-              </Button>
+              <div data-test-item-details>
+                <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`}>
+                  <FormattedMessage id="ui-checkin.itemDetails" />
+                </Button>
+              </div>
             </MenuItem>
           </DropdownMenu>
         </UncontrolledDropdown>

--- a/Scan.js
+++ b/Scan.js
@@ -144,26 +144,32 @@ class Scan extends React.Component {
 
   renderActions(loan) {
     return (
-      <UncontrolledDropdown onSelectItem={this.handleOptionsChange}>
-        <Button data-role="toggle" buttonStyle="hover dropdownActive"><strong>•••</strong></Button>
-        <DropdownMenu data-role="menu" overrideStyle={{ padding: '6px 0' }}>
-          <MenuItem itemMeta={{ loan, action: 'showLoanDetails' }}>
-            <Button buttonStyle="dropdownItem" href={`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`}>
-              <FormattedMessage id="ui-checkin.loanDetails" />
-            </Button>
-          </MenuItem>
-          <MenuItem itemMeta={{ loan, action: 'showPatronDetails' }}>
-            <Button buttonStyle="dropdownItem" href={`/users/view/${_.get(loan, ['patron', 'id'])}`}>
-              <FormattedMessage id="ui-checkin.patronDetails" />
-            </Button>
-          </MenuItem>
-          <MenuItem itemMeta={{ loan, action: 'showItemDetails' }}>
-            <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`}>
-              <FormattedMessage id="ui-checkin.itemDetails" />
-            </Button>
-          </MenuItem>
-        </DropdownMenu>
-      </UncontrolledDropdown>
+      <div data-test-elipse-select>
+        <UncontrolledDropdown onSelectItem={this.handleOptionsChange}>
+          <Button data-role="toggle" buttonStyle="hover dropdownActive"><strong>•••</strong></Button>
+          <DropdownMenu data-role="menu" overrideStyle={{ padding: '6px 0' }}>
+            <MenuItem itemMeta={{ loan, action: 'showLoanDetails' }}>
+              <div data-test-loan-details>
+                <Button buttonStyle="dropdownItem" href={`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`}>
+                  <FormattedMessage id="ui-checkin.loanDetails" />
+                </Button>
+              </div>
+            </MenuItem>
+            <MenuItem itemMeta={{ loan, action: 'showPatronDetails' }}>
+              <div data-test-patron-details>
+                <Button buttonStyle="dropdownItem" href={`/users/view/${_.get(loan, ['patron', 'id'])}`}>
+                  <FormattedMessage id="ui-checkin.patronDetails" />
+                </Button>
+              </div>
+            </MenuItem>
+            <MenuItem itemMeta={{ loan, action: 'showItemDetails' }}>
+              <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`}>
+                <FormattedMessage id="ui-checkin.itemDetails" />
+              </Button>
+            </MenuItem>
+          </DropdownMenu>
+        </UncontrolledDropdown>
+      </div>
     );
   }
 

--- a/bigtest/interactors/check-in.js
+++ b/bigtest/interactors/check-in.js
@@ -15,6 +15,7 @@ export default interactor(class CheckInInteractor {
   selectElipse = clickable('[data-test-elipse-select]');
   selectLoanDetails = clickable('[data-test-loan-details]');
   selectPatronDetails = clickable('[data-test-patron-details]');
+  selectItemDetails = clickable('[data-test-item-details]');
   barcodePresent = isPresent('[data-test-check-in-barcode]');
   barcode = fillable('#input-item-barcode');
   clickEnter = clickable('#clickable-add-item');

--- a/bigtest/interactors/check-in.js
+++ b/bigtest/interactors/check-in.js
@@ -12,6 +12,9 @@ import TimepickerInteractor from '@folio/stripes-components/lib/Timepicker/tests
 export default interactor(class CheckInInteractor {
   processDate = new DatepickerInteractor('[data-test-process-date]')
   processTime = new TimepickerInteractor('[data-test-process-time]')
+  selectElipse = clickable('[data-test-elipse-select]');
+  selectLoanDetails = clickable('[data-test-loan-details]');
+  selectPatronDetails = clickable('[data-test-patron-details]');
   barcodePresent = isPresent('[data-test-check-in-barcode]');
   barcode = fillable('#input-item-barcode');
   clickEnter = clickable('#clickable-add-item');

--- a/bigtest/interactors/check-in.js
+++ b/bigtest/interactors/check-in.js
@@ -16,6 +16,7 @@ export default interactor(class CheckInInteractor {
   selectLoanDetails = clickable('[data-test-loan-details]');
   selectPatronDetails = clickable('[data-test-patron-details]');
   selectItemDetails = clickable('[data-test-item-details]');
+  fillOutError = text('[data-test-check-in-scan] [class^="feedbackError"]');
   barcodePresent = isPresent('[data-test-check-in-barcode]');
   barcode = fillable('#input-item-barcode');
   clickEnter = clickable('#clickable-add-item');

--- a/bigtest/interactors/check-in.js
+++ b/bigtest/interactors/check-in.js
@@ -6,7 +6,12 @@ import {
   text
 } from '@bigtest/interactor';
 
+import DatepickerInteractor from '@folio/stripes-components/lib/Datepicker/tests/interactor';
+import TimepickerInteractor from '@folio/stripes-components/lib/Timepicker/tests/interactor';
+
 export default interactor(class CheckInInteractor {
+  processDate = new DatepickerInteractor('[data-test-process-date]')
+  processTime = new TimepickerInteractor('[data-test-process-time]')
   barcodePresent = isPresent('[data-test-check-in-barcode]');
   barcode = fillable('#input-item-barcode');
   clickEnter = clickable('#clickable-add-item');

--- a/bigtest/network/factories/item.js
+++ b/bigtest/network/factories/item.js
@@ -5,6 +5,7 @@ export default Factory.extend({
   barcode: () => Math.floor(Math.random() * 9000000000000) + 1000000000000,
   instanceId: () => faker.random.uuid(),
   callNumber: () => Math.floor(Math.random() * 90000000) + 10000000,
+  holdingsRecordId: () => faker.random.uuid(),
 
   materialType: () => {
     return { name: faker.random.word() };

--- a/bigtest/tests/check-in-test.js
+++ b/bigtest/tests/check-in-test.js
@@ -84,13 +84,7 @@ describeApplication('CheckIn', () => {
   });
 
   describe('navigating to loan details', () => {
-    let body;
     beforeEach(async function () {
-      this.server.put('/circulation/loans/:id', (_, request) => {
-        body = JSON.parse(request.requestBody);
-        return body;
-      });
-
       this.server.create('item', 'withLoan', {
         barcode: 9676761472500,
         title: 'Best Book Ever',
@@ -106,18 +100,12 @@ describeApplication('CheckIn', () => {
 
     it('directs to loan details page', function () {
       const { search, pathname } = this.app.history.location;
-      expect(pathname + search).to.include('/users/view/6?layer=loan&loan=6'); // i don't actually know where this came from
+      expect(pathname + search).to.include('/users/view/6?layer=loan&loan=6');
     });
   });
 
   describe('navigating to patron details', () => {
-    let body;
     beforeEach(async function () {
-      this.server.put('/circulation/loans/:id', (_, request) => {
-        body = JSON.parse(request.requestBody);
-        return body;
-      });
-
       this.server.create('item', 'withLoan', {
         barcode: 9676761472500,
         title: 'Best Book Ever',
@@ -133,7 +121,30 @@ describeApplication('CheckIn', () => {
 
     it('directs to patron details page', function () {
       const { search, pathname } = this.app.history.location;
-      expect(pathname + search).to.include('/users/view/6'); // i don't actually know where this came from
+      expect(pathname + search).to.include('/users/view/6');
+    });
+  });
+
+  describe('navigating to item details', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472500,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        },
+        instanceId : 'lychee',
+        holdingsRecordId : 'apple'
+      });
+
+      await checkIn.barcode('9676761472500').clickEnter();
+      await checkIn.selectElipse();
+      await checkIn.selectItemDetails();
+    });
+
+    it('directs to item details page', function () {
+      const { search, pathname } = this.app.history.location;
+      expect(pathname + search).to.include('/inventory/view/lychee/apple/6');
     });
   });
 });

--- a/bigtest/tests/check-in-test.js
+++ b/bigtest/tests/check-in-test.js
@@ -56,6 +56,25 @@ describeApplication('CheckIn', () => {
     });
   });
 
+  describe('submitting the check-in without a barcode', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472500,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        }
+      });
+
+      await checkIn.processDate.fillAndBlur('04/25/2018');
+      await checkIn.processTime.fillInput('4:25 PM').clickEnter();
+    });
+
+    it('throws the fillOut error', () => {
+      expect(checkIn.fillOutError).to.equal('Please fill this out to continue');
+    });
+  });
+
   describe('changing check-in date and time', () => {
     let body;
     beforeEach(async function () {

--- a/bigtest/tests/check-in-test.js
+++ b/bigtest/tests/check-in-test.js
@@ -55,4 +55,31 @@ describeApplication('CheckIn', () => {
       });
     });
   });
+
+  describe('changing check-in date and time', () => {
+    let body;
+    beforeEach(async function () {
+      this.server.put('/circulation/loans/:id', (_, request) => {
+        body = JSON.parse(request.requestBody);
+        return body;
+      });
+
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472500,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        }
+      });
+
+      await checkIn.processDate.fillAndBlur('04/25/2018');
+      await checkIn.processTime.fillInput('4:25 PM');
+      await checkIn.barcode('9676761472500').clickEnter();
+    });
+
+    it('changes the date and time in the payload', () => {
+      expect(body.systemReturnDate).to.include('2018-04-25');
+      expect(body.systemReturnDate).to.include('16:25:00');
+    });
+  });
 });

--- a/bigtest/tests/check-in-test.js
+++ b/bigtest/tests/check-in-test.js
@@ -82,4 +82,58 @@ describeApplication('CheckIn', () => {
       expect(body.systemReturnDate).to.include('16:25:00');
     });
   });
+
+  describe('navigating to loan details', () => {
+    let body;
+    beforeEach(async function () {
+      this.server.put('/circulation/loans/:id', (_, request) => {
+        body = JSON.parse(request.requestBody);
+        return body;
+      });
+
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472500,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        }
+      });
+
+      await checkIn.barcode('9676761472500').clickEnter();
+      await checkIn.selectElipse();
+      await checkIn.selectLoanDetails();
+    });
+
+    it('directs to loan details page', function () {
+      const { search, pathname } = this.app.history.location;
+      expect(pathname + search).to.include('/users/view/6?layer=loan&loan=6'); // i don't actually know where this came from
+    });
+  });
+
+  describe('navigating to patron details', () => {
+    let body;
+    beforeEach(async function () {
+      this.server.put('/circulation/loans/:id', (_, request) => {
+        body = JSON.parse(request.requestBody);
+        return body;
+      });
+
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472500,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        }
+      });
+
+      await checkIn.barcode('9676761472500').clickEnter();
+      await checkIn.selectElipse();
+      await checkIn.selectPatronDetails();
+    });
+
+    it('directs to patron details page', function () {
+      const { search, pathname } = this.app.history.location;
+      expect(pathname + search).to.include('/users/view/6'); // i don't actually know where this came from
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "chai-jquery": "^2.0.0",
     "eslint": "^4.8.0",
     "jquery": "^3.3.1",
-    "karma-webpack": "^3.0.0",
+    "karma-webpack": "2.0.6",
     "mocha": "^5.2.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
@@ -95,5 +95,8 @@
     "@folio/stripes-connect": "^2.2.1",
     "@folio/stripes-core": "^2.1.0",
     "react": "*"
+  },
+  "resolutions": {
+    "karma-webpack": "2.0.6"
   }
 }


### PR DESCRIPTION
UIEH-505 BigTest
Add repository-level isolated tests around ui-checkin module

## Purpose
There are currently a number of gaps in the code testing coverage; the purpose is to fill in these gaps of the original PR.

https://issues.folio.org/browse/UIEH-505

## Approach
This change includes 5 new tests that cover navigation within the dropdown menu (loan, patron, and item details), check-in submission without the inclusion of a barcode (throwing an error), and changing the date and time for the check-in.

## Learning
- Window location and how you can wield this to ensure that the application is changing pages correctly.
- Writing tests for an application that communicates with a server.
- Wrapping elements in a named div and using that name in tests to make buttons clickable.
- How to mock requests to the server and test the data being sent.
        - Writing tests from the point of view of a user as opposed to that of individual component tests.

## Screenshots
Coverage report after the addition of the new tests:
<img width="448" alt="capture36547" src="https://user-images.githubusercontent.com/41590532/44232858-55a3b000-a170-11e8-8c5e-992dd694b37e.PNG">
